### PR TITLE
FEATURE: Add aliasing to :white_check_mark: emoji

### DIFF
--- a/lib/discourse_emojis/constants.rb
+++ b/lib/discourse_emojis/constants.rb
@@ -683,7 +683,7 @@ module DiscourseEmojis
     "trident_emblem" => ["trident"],
     "japanese_symbol_for_beginner" => ["beginner"],
     "hollow_red_circle" => ["o"],
-    "white_check_mark" => ["check_mark_button"],
+    "white_check_mark" => %w[check_mark_button lgtm green_check_mark],
     "check_box_with_check" => ["ballot_box_with_check"],
     "check_mark" => ["heavy_check_mark"],
     "cross_mark" => ["x"],

--- a/lib/discourse_emojis/version.rb
+++ b/lib/discourse_emojis/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DiscourseEmojis
-  VERSION = "1.0.43"
+  VERSION = "1.0.44"
 end


### PR DESCRIPTION
Maybe we could have aliasing at user level?

It feels correct to have :lgtm: and :green_check_mark: as aliases for :white_check_mark: